### PR TITLE
Use mn source-fonts

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -38,25 +38,6 @@ jobs:
           export RENAME_FONTS=false
           curl -Ls https://raw.githubusercontent.com/metanorma/vista-fonts-installer/master/vista-fonts-installer.sh | bash
 
-      - name: Install System Fonts
-        run: |
-          export MN_PDF_FONT_PATH=${GITHUB_WORKSPACE}/fonts
-          mkdir -p ${MN_PDF_FONT_PATH}/truetype/msttcorefonts
-          ls -alR /System/Library/Fonts
-          ln -s /System/Library/Fonts/Supplemental/Arial.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/arial.ttf
-          ln -s /System/Library/Fonts/Supplemental/Arial\ Bold.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/arialbd.ttf
-          ln -s /System/Library/Fonts/Supplemental/Arial\ Italic.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/ariali.ttf
-          ln -s /System/Library/Fonts/Supplemental/Arial\ Bold\ Italic.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/arialbi.ttf
-          ln -s /System/Library/Fonts/Supplemental/Times\ New\ Roman.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/times.ttf
-          ln -s /System/Library/Fonts/Supplemental/Times\ New\ Roman\ Bold.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/timesbd.ttf
-          ln -s /System/Library/Fonts/Supplemental/Times\ New\ Roman\ Italic.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/timesi.ttf
-          ln -s /System/Library/Fonts/Supplemental/Times\ New\ Roman\ Bold\ Italic.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/timesbi.ttf
-          ln -s /System/Library/Fonts/Supplemental/Courier\ New.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/cour.ttf
-          ln -s /System/Library/Fonts/Supplemental/Courier\ New\ Bold.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/courbd.ttf
-          ln -s /System/Library/Fonts/Supplemental/Courier\ New\ Bold\ Italic.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/courbi.ttf
-          ln -s /System/Library/Fonts/Supplemental/Courier\ New\ Italic.ttf ${MN_PDF_FONT_PATH}/truetype/msttcorefonts/couri.ttf
-          ls -alR ${MN_PDF_FONT_PATH}
-
       - name: Build
         run: |
           make all

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@master
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -21,12 +23,13 @@ jobs:
           # Install Maven
           brew install maven
 
-          # Install p7zip
-          brew install p7zip
           # Install cabextract
           brew install cabextract
 
-      - uses: actions/checkout@master
+      - name: Setup Source fonts
+        run: |
+          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
+          unzip source-fonts.zip
 
       - name: Install Microsoft Vista fonts
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,11 +26,6 @@ jobs:
           # Install cabextract
           brew install cabextract
 
-#      - name: Setup Source fonts
-#        run: |
-#          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
-#          unzip source-fonts.zip
-
       - name: Install Microsoft Vista fonts
         run: |
           export MN_PDF_FONT_PATH=${GITHUB_WORKSPACE}/fonts

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,10 +26,10 @@ jobs:
           # Install cabextract
           brew install cabextract
 
-      - name: Setup Source fonts
-        run: |
-          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
-          unzip source-fonts.zip
+#      - name: Setup Source fonts
+#        run: |
+#          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
+#          unzip source-fonts.zip
 
       - name: Install Microsoft Vista fonts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,16 @@ jobs:
       - name: Setup prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get -y install cabextract p7zip-full libxml2-utils
-
-          # Install fonts
-          sudo apt-get -y install fonts-freefont-ttf
+          sudo apt-get -y install cabextract libxml2-utils
 
           # If necessary
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
+
+      - name: Setup Source fonts
+        run: |
+          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
+          unzip source-fonts.zip
 
       - name: Setup Cambria fonts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,6 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
 
-#      - name: Setup Source fonts
-#        run: |
-#          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
-#          unzip source-fonts.zip
-
       - name: Setup Cambria fonts
         run: |
           curl -Ls https://raw.githubusercontent.com/metanorma/vista-fonts-installer/master/vista-fonts-installer.sh | sudo bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,10 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
 
-      - name: Setup Source fonts
-        run: |
-          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
-          unzip source-fonts.zip
+#      - name: Setup Source fonts
+#        run: |
+#          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
+#          unzip source-fonts.zip
 
       - name: Setup Cambria fonts
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,10 +27,10 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
 
-      - name: Setup Source fonts
-        run: |
-          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
-          unzip source-fonts.zip
+#      - name: Setup Source fonts
+#        run: |
+#          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
+#          unzip source-fonts.zip
 
       - name: Setup Cambria fonts
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@master
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -19,20 +21,20 @@ jobs:
       - name: Setup prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get -y install cabextract p7zip-full libxml2-utils
-
-          # Install fonts
-          sudo apt-get -y install fonts-freefont-ttf
+          sudo apt-get -y install cabextract libxml2-utils
 
           # If necessary
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
 
+      - name: Setup Source fonts
+        run: |
+          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
+          unzip source-fonts.zip
+
       - name: Setup Cambria fonts
         run: |
           curl -Ls https://raw.githubusercontent.com/metanorma/vista-fonts-installer/master/vista-fonts-installer.sh | sudo bash
-
-      - uses: actions/checkout@master
 
       - name: Build
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,11 +27,6 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
 
-#      - name: Setup Source fonts
-#        run: |
-#          curl -sSL -o source-fonts.zip https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip
-#          unzip source-fonts.zip
-
       - name: Setup Cambria fonts
         run: |
           curl -Ls https://raw.githubusercontent.com/metanorma/vista-fonts-installer/master/vista-fonts-installer.sh | sudo bash

--- a/Makefile
+++ b/Makefile
@@ -10,58 +10,7 @@ PATHSEP := $(strip $(PATHSEP2))
 JAR_VERSION := $(shell mvn -q -Dexec.executable="echo" -Dexec.args='$${project.version}' --non-recursive exec:exec -DforceStdout)
 JAR_FILE := mn2pdf-$(JAR_VERSION).jar
 
-FONTS := \
-	SourceCodePro-Black.ttf \
-	SourceCodePro-BlackIt.ttf \
-	SourceCodePro-Bold.ttf \
-	SourceCodePro-BoldIt.ttf \
-	SourceCodePro-ExtraLight.ttf \
-	SourceCodePro-ExtraLightIt.ttf \
-	SourceCodePro-It.ttf \
-	SourceCodePro-Light.ttf \
-	SourceCodePro-LightIt.ttf \
-	SourceCodePro-Medium.ttf \
-	SourceCodePro-MediumIt.ttf \
-	SourceCodePro-Regular.ttf \
-	SourceCodePro-Semibold.ttf \
-	SourceCodePro-SemiboldIt.ttf \
-	SourceSansPro-Black.ttf \
-	SourceSansPro-BlackIt.ttf \
-	SourceSansPro-Bold.ttf \
-	SourceSansPro-BoldIt.ttf \
-	SourceSansPro-ExtraLight.ttf \
-	SourceSansPro-ExtraLightIt.ttf \
-	SourceSansPro-It.ttf \
-	SourceSansPro-Light.ttf \
-	SourceSansPro-LightIt.ttf \
-	SourceSansPro-Regular.ttf \
-	SourceSansPro-Semibold.ttf \
-	SourceSansPro-SemiboldIt.ttf \
-	SourceSerifPro-Black.ttf \
-	SourceSerifPro-BlackIt.ttf \
-	SourceSerifPro-Bold.ttf \
-	SourceSerifPro-BoldIt.ttf \
-	SourceSerifPro-ExtraLight.ttf \
-	SourceSerifPro-ExtraLightIt.ttf \
-	SourceSerifPro-It.ttf \
-	SourceSerifPro-Light.ttf \
-	SourceSerifPro-LightIt.ttf \
-	SourceSerifPro-Regular.ttf \
-	SourceSerifPro-Semibold.ttf \
-	SourceSerifPro-SemiboldIt.ttf \
-	SourceHanSans-Bold.ttc \
-	SourceHanSans-ExtraLight.ttc \
-	SourceHanSans-Heavy.ttc \
-	SourceHanSans-Light.ttc \
-	SourceHanSans-Medium.ttc \
-	SourceHanSans-Normal.ttc \
-	SourceHanSans-Regular.ttc
-
-FONTS := $(addprefix src/main/resources/fonts/,$(FONTS))
-
-all: $(FONTS) target/$(JAR_FILE)
-
-allfonts: $(FONTS)
+all: target/$(JAR_FILE)
 
 target/$(JAR_FILE):
 	mvn -DskipTests clean package shade:shade
@@ -72,32 +21,7 @@ test: target/$(JAR_FILE)
 clean:
 	mvn clean
 
-fontclean:
-	rm -rf fonts
-
-src/main/resources/fonts:
-	mkdir -p $(subst /,$(PATHSEP),$@)
-
-src/main/resources/fonts/SourceSansPro-%: | src/main/resources/fonts
-	curl -sSL -o $@ https://github.com/adobe-fonts/source-sans-pro/raw/release/TTF/$(notdir $@)
-
-src/main/resources/fonts/SourceSerifPro-%: | src/main/resources/fonts
-	curl -sSL -o $@ https://github.com/adobe-fonts/source-serif-pro/raw/release/TTF/$(notdir $@)
-
-src/main/resources/fonts/SourceCodePro-%: | src/main/resources/fonts
-	curl -sSL -o $@ https://github.com/adobe-fonts/source-code-pro/raw/release/TTF/$(notdir $@)
-
-tmp/SourceHanSans.7z:
-	curl -ssL -o $@ https://github.com/Pal3love/Source-Han-TrueType/raw/master/SourceHanSans.7z
-
-tmp/SourceHanSans-%.ttc: tmp/SourceHanSans.7z
-	7za e -y $< -otmp
-	touch tmp/*.ttc
-
-src/main/resources/fonts/SourceHanSans-%.ttc: tmp/SourceHanSans-%.ttc
-	cp $< $@
-
 version:
 	echo "${JAR_VERSION}"
 
-.PHONY: all clean allfonts fontclean test version
+.PHONY: all clean test version

--- a/README.adoc
+++ b/README.adoc
@@ -14,14 +14,14 @@ You will need the `maven` build tool and `make`.
 
 [source,sh]
 ----
-java -jar target/mn2pdf-1.3.jar <PDF-Font-Config> <XML-FileName> <XSLT-FileName> <Output-PDF-FileName>
+java -jar target/mn2pdf-1.4.jar --xml-file <XML-FileName> --xsl-file <XSLT-FileName> --pdf-file <Output-PDF-FileName>
 ----
 
 e.g.
 
 [source,sh]
 ----
-java -jar target/mn2pdf-1.3.jar tests/pdf_fonts_config.xml tests/G.191.xml tests/itu.recommendation.xsl tests/G.191.pdf
+java -jar target/mn2pdf-1.4.jar --xml-file tests/G.191.xml --xsl-file tests/itu.recommendation.xsl --pdf-file tests/G.191.pdf
 ----
 
 
@@ -41,7 +41,7 @@ Update version in `pom.xml`, e.g.:
 ----
 <groupId>com.metanorma.fop</groupId>
 <artifactId>mn2pdf</artifactId>
-<version>1.3</version>
+<version>1.4</version>
 <name>Metanorma XML to PDF converter</name>
 ----
 
@@ -52,8 +52,8 @@ Tag the same version in Git:
 
 [source,xml]
 ----
-git tag v1.3
-git push origin v1.3
+git tag v1.4
+git push origin v1.4
 ----
 
 Then the corresponding GitHub release will be automatically created at:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.metanorma.fop</groupId>
 	<artifactId>mn2pdf</artifactId>
-	<version>1.3</version>
+	<version>1.4</version>
 	<name>Metanorma XML to PDF converter</name>
 	<packaging>jar</packaging>
 	<url>https://www.metanorma.com</url>
@@ -61,8 +61,14 @@
 			</plugins>
 	</build>
 	<dependencies>
+                <dependency>
+                    <groupId>commons-cli</groupId>
+                    <artifactId>commons-cli</artifactId>
+                    <version>1.4</version>
+                </dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.xmlgraphics/fop -->
-		<dependency>
+	 
+                <dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>fop</artifactId>
 			<version>2.4</version>

--- a/src/main/java/com/metanorma/fop/Util.java
+++ b/src/main/java/com/metanorma/fop/Util.java
@@ -1,0 +1,92 @@
+package com.metanorma.fop;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ *
+ * @author Alexander Dyuzhev
+ */
+public class Util {
+    
+    public static int getFileSize(URL url) {
+        URLConnection conn = null;
+        try {
+            conn = url.openConnection();
+            return conn.getContentLength();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if(conn instanceof HttpURLConnection) {
+                ((HttpURLConnection)conn).disconnect();
+            }
+        }
+    }
+    
+    public static void downloadFile(String url, Path destPath) {
+        System.out.println("Downloading " + url + "...");
+        try {
+            ReadableByteChannel readableByteChannel = Channels.newChannel(new URL(url).openStream());
+            FileOutputStream fileOutputStream = new FileOutputStream(destPath.toString());
+            fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        } catch (Exception ex) {
+            System.out.println("Can't downloaded a file: " + ex.getMessage());
+        }
+    }
+    
+    // https://www.baeldung.com/java-compress-and-uncompress
+    public static void unzipFile(Path zipPath, String destPath, ArrayList<String> defaultFontList) {
+        try {
+            File destDir = new File(destPath);
+            byte[] buffer = new byte[1024];
+            ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath.toString()));
+            ZipEntry zipEntry = zis.getNextEntry();
+            while (zipEntry != null) {
+                if(!zipEntry.isDirectory()) {
+                    String zipEntryName = new File(zipEntry.getName()).getName();
+                    if (defaultFontList.contains(zipEntryName)) {
+                        //File newFile = newFile(destDir, zipEntry);
+                        File newFile = new File(destDir, zipEntryName);
+                        FileOutputStream fos = new FileOutputStream(newFile);
+                        int len;
+                        while ((len = zis.read(buffer)) > 0) {
+                            fos.write(buffer, 0, len);
+                        }
+                        fos.close();
+                    }
+                }
+                zipEntry = zis.getNextEntry();
+            }
+            zis.closeEntry();
+            zis.close();
+        } catch (Exception ex) {
+            System.out.println("Can't unzip a file: " + ex.getMessage());
+        }
+    }
+    
+    // These method guards against writing files to the file system outside of the target folder. 
+    // This vulnerability is called Zip Slip and you can read more about it here: https://snyk.io/research/zip-slip-vulnerability
+    private static File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
+        File destFile = new File(destinationDir, zipEntry.getName());
+         
+        String destDirPath = destinationDir.getCanonicalPath();
+        String destFilePath = destFile.getCanonicalPath();
+         
+        if (!destFilePath.startsWith(destDirPath + File.separator)) {
+            throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+        }
+         
+        return new File(destinationDir, new File(zipEntry.getName()).getName());
+    }
+}

--- a/src/main/java/com/metanorma/fop/Util.java
+++ b/src/main/java/com/metanorma/fop/Util.java
@@ -58,6 +58,7 @@ public class Util {
                     if (defaultFontList.contains(zipEntryName)) {
                         //File newFile = newFile(destDir, zipEntry);
                         File newFile = new File(destDir, zipEntryName);
+                        System.out.println("Extracting font file " + newFile.getAbsolutePath() + "...");
                         FileOutputStream fos = new FileOutputStream(newFile);
                         int len;
                         while ((len = zis.read(buffer)) > 0) {

--- a/src/main/java/com/metanorma/fop/fontConfig.java
+++ b/src/main/java/com/metanorma/fop/fontConfig.java
@@ -19,6 +19,7 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import java.util.stream.Stream;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -94,7 +95,7 @@ class fontConfig {
             //Files.copy(fontfilestream, destPath, StandardCopyOption.REPLACE_EXISTING);
         }
         if (!fontstocopy.isEmpty()) {
-            String url = "https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip";
+            String url = getFontsURL();
             int remotefilesize = Util.getFileSize(new URL(url));
             final Path destZipPath = Paths.get(fontPath, "source-fonts.zip");
             if (!destZipPath.toFile().exists() || Files.size(destZipPath) != remotefilesize) {
@@ -303,5 +304,9 @@ class fontConfig {
         return substsuffix;
     }
     
-    
+    private String getFontsURL() throws Exception {
+        Properties appProps = new Properties();
+        appProps.load(getStreamFromResources("app.properties"));
+        return appProps.getProperty("sourcefontsURL");
+    }
 }

--- a/src/main/java/com/metanorma/fop/fontConfig.java
+++ b/src/main/java/com/metanorma/fop/fontConfig.java
@@ -12,7 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -85,10 +84,32 @@ class fontConfig {
         fontPath = fontPath.replace("~", System.getProperty("user.home"));
         new File(fontPath).mkdirs();
         
+        ArrayList<String> fontstocopy = new ArrayList<>();
         for (String fontfilename: defaultFontList) {
-            InputStream fontfilestream = getStreamFromResources("fonts/" + fontfilename);
             final Path destPath = Paths.get(fontPath, fontfilename);
-            Files.copy(fontfilestream, destPath, StandardCopyOption.REPLACE_EXISTING);
+            if (!destPath.toFile().exists()) {
+                fontstocopy.add(fontfilename);
+            }            
+            //InputStream fontfilestream = getStreamFromResources("fonts/" + fontfilename);            
+            //Files.copy(fontfilestream, destPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+        if (!fontstocopy.isEmpty()) {
+            String url = "https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip";
+            int remotefilesize = Util.getFileSize(new URL(url));
+            final Path destZipPath = Paths.get(fontPath, "source-fonts.zip");
+            if (!destZipPath.toFile().exists() || Files.size(destZipPath) != remotefilesize) {
+                // download a file
+                Util.downloadFile(url, destZipPath);
+            }
+            // unzip file to fontPath
+            Util.unzipFile(destZipPath, fontPath, defaultFontList);
+            // check existing files
+            for (String fontfilename: defaultFontList) {
+                final Path destPath = Paths.get(fontPath, fontfilename);
+                if (!destPath.toFile().exists()) {
+                    System.out.println("Can't file a font file: " + destPath.toString());
+                }
+            }
         }
     }
     
@@ -281,4 +302,6 @@ class fontConfig {
         }
         return substsuffix;
     }
+    
+    
 }

--- a/src/main/resources/app.properties
+++ b/src/main/resources/app.properties
@@ -1,0 +1,1 @@
+sourcefontsURL=https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip

--- a/src/test/java/com/metanorma/fop/mn2pdfTests.java
+++ b/src/test/java/com/metanorma/fop/mn2pdfTests.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.apache.commons.cli.ParseException;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,7 +26,7 @@ public class mn2pdfTests {
     public final EnvironmentVariables envVarRule = new EnvironmentVariables();
 
     @Test
-    public void notEnoughArguments() {
+    public void notEnoughArguments() throws ParseException {
         exitRule.expectSystemExitWithStatus(-1);
         String[] args = new String[]{"1", "2", "3"};
         mn2pdf.main(args);
@@ -48,12 +49,12 @@ public class mn2pdfTests {
     }*/
     
     @Test
-    public void xmlNotExists() {
+    public void xmlNotExists() throws ParseException {
         exitRule.expectSystemExitWithStatus(-1);
 
         String fontpath = System.getProperty("buildDirectory") + File.separator + ".." + File.separator + "fonts";
 
-        String[] args = new String[]{fontpath, "2", "3", "4"};
+        String[] args = new String[]{"--xml-file", "1", "--xsl-file", "2", "--pdf-file", "3"};
         mn2pdf.main(args);
 
         assertTrue(systemOutRule.getLog().contains(
@@ -61,14 +62,14 @@ public class mn2pdfTests {
     }
 
     @Test
-    public void xslNotExists() {
+    public void xslNotExists() throws ParseException {
         exitRule.expectSystemExitWithStatus(-1);
 
         ClassLoader classLoader = getClass().getClassLoader();
         String fontpath = System.getProperty("buildDirectory") + File.separator + ".." + File.separator + "fonts";
         String xml = classLoader.getResource("G.191.xml").getFile();
 
-        String[] args = new String[]{fontpath, xml, "3", "4"};
+        String[] args = new String[]{"--xml-file", xml, "--xsl-file", "3", "--pdf-file", "4"};
         mn2pdf.main(args);
 
         assertTrue(systemOutRule.getLog().contains(
@@ -91,14 +92,14 @@ public class mn2pdfTests {
  		assertTrue(systemOutRule.getLog().contains(fontConfig.ENV_FONT_PATH));
     }*/
     @Test
-    public void success() {
+    public void success() throws ParseException {
         ClassLoader classLoader = getClass().getClassLoader();
-        String fontpath = ((System.getenv("MN_PDF_FONT_PATH") == null) ? System.getProperty("buildDirectory") + File.separator + ".." + File.separator + "fonts" : System.getenv("MN_PDF_FONT_PATH"));
+        String fontpath = Paths.get(System.getProperty("buildDirectory"), ".." , "fonts").toString();
         String xml = classLoader.getResource("G.191.xml").getFile();
         String xsl = classLoader.getResource("itu.recommendation.xsl").getFile();
         Path pdf = Paths.get(System.getProperty("buildDirectory"), "G.191.pdf");
 
-        String[] args = new String[]{fontpath, xml, xsl, pdf.toAbsolutePath().toString()};
+        String[] args = new String[]{"--font-path", fontpath, "--xml-file",  xml, "--xsl-file", xsl, "--pdf-file", pdf.toAbsolutePath().toString()};
         mn2pdf.main(args);
 
         assertTrue(Files.exists(pdf));


### PR DESCRIPTION
The Adobe Source * fonts we use are now in https://github.com/metanorma/source-fonts . 

The fonts can simply be downloaded from: https://github.com/metanorma/source-fonts/releases/download/v1.0/source-fonts-1.0.zip

On first launch of `mn2pdf`, it should download these fonts to the font directory and expand them in there.